### PR TITLE
RHEL6 package provide file /usr/bin/pip

### DIFF
--- a/manifests/pip.pp
+++ b/manifests/pip.pp
@@ -5,7 +5,7 @@ class python::pip {
     ensure => present,
   }
 
-  if $::osfamily == 'RedHat' and $::lsbmajdistrelease<6 {
+  if $::osfamily == 'RedHat' and $::lsbmajdistrelease<'6' {
     file {'/usr/bin/pip':
       ensure  => 'link',
       target  => '/usr/bin/pip-python',


### PR DESCRIPTION
On RHEL6, the pip-python package provide:
the /usr/bin/pip file
the /usr/bin/pip-python link (on the pip file)

The python::pip class set /usr/bin/pip as a link on /usr/bin/pip-python, then we have two dead links.

Maybe a previous package (for rhel5?) provided a file pip-python without pip link (?)

This patch ensure we don't destroy the pip file provided by the package, for RHEL >=6
