### PR TITLE
Use namevar, not alias

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,20 +12,14 @@ form of virtual resources. Wherever a library is needed you just have to
 write the following lines:
 
     include python::package::simplejson
-    Package <| alias == 'python-simplejson' |>
+    realize Package['python-simplejson']
 
 If you prefer pip packages:
 
     include python::pip
-    include python::pip::json
-    Package <| alias == 'python-simplejson' |>
+    include python::pip::simplejson
+    realize Package['python-simplejson']
 
-Due to a bug (http://projects.puppetlabs.com/issues/4459) resource alias 
-is only usable for require. For example:
-
-    realize Package[python-simplejson]
-
-doesn't work! This is why we use the "spaceship" (collection) operator.
 
 ## Dependencies
 

--- a/manifests/dev.pp
+++ b/manifests/dev.pp
@@ -18,7 +18,6 @@ class python::dev {
 
   package { 'python-dev':
     ensure => present,
-    alias  => 'python-devel',
     name   => $pkg,
   }
 

--- a/manifests/package/argparse.pp
+++ b/manifests/package/argparse.pp
@@ -5,7 +5,7 @@
 # === Example
 #
 # include python::package::argparse
-# Package <| alias == 'python-argparse' |>
+# realize Package['python-argparse']
 #
 class python::package::argparse {
 
@@ -16,7 +16,6 @@ class python::package::argparse {
   )
 
   @package {'python-argparse':
-    alias => 'python-argparse',
   }
 
 }

--- a/manifests/package/couchdb.pp
+++ b/manifests/package/couchdb.pp
@@ -5,7 +5,7 @@
 # === Example
 #
 # include python::package::couchdb
-# Package <| alias == 'python-couchdb' |>
+# realize Package['python-couchdb']
 #
 class python::package::couchdb {
 
@@ -16,7 +16,6 @@ class python::package::couchdb {
   )
 
   @package {'python-couchdb':
-    alias => 'python-couchdb',
   }
 
 }

--- a/manifests/package/ordereddict.pp
+++ b/manifests/package/ordereddict.pp
@@ -5,7 +5,7 @@
 # === Example
 #
 # include python::package::ordereddict
-# Package <| alias == 'python-ordereddict' |>
+# realize Package['python-ordereddict']
 #
 class python::package::ordereddict {
 
@@ -16,7 +16,6 @@ class python::package::ordereddict {
   )
 
   @package {'python-ordereddict':
-    alias => 'python-ordereddict',
   }
 
 }

--- a/manifests/package/simplejson.pp
+++ b/manifests/package/simplejson.pp
@@ -5,7 +5,7 @@
 # === Example
 #
 # include python::package::simplejson
-# Package <| alias == 'python-simplejson' |>
+# realize Package['python-simplejson']
 #
 class python::package::simplejson {
 
@@ -16,7 +16,6 @@ class python::package::simplejson {
   )
 
   @package {'python-simplejson':
-    alias => 'python-simplejson',
   }
 
 }

--- a/manifests/pip/couchdb.pp
+++ b/manifests/pip/couchdb.pp
@@ -6,7 +6,7 @@
 #
 # include python::pip
 # include python::pip::couchdb
-# Package <| alias == 'python-couchdb' |>
+# realize Package['python-couchdb']
 #
 class python::pip::couchdb {
 
@@ -19,9 +19,9 @@ class python::pip::couchdb {
   # Workaround: added a SPACE in namevar to avoid duplicate declaration
   # with the service/package couchdb! Hoping that one day we can properly solve
   # this problem using e.g. composite name identifier
-  @package {' couchdb':
+  @package {'python-couchdb':
     provider => 'pip',
-    alias    => 'python-couchdb',
+    name     => 'couchdb',
   }
 
 }

--- a/manifests/pip/pyes.pp
+++ b/manifests/pip/pyes.pp
@@ -6,7 +6,7 @@
 #
 # include python::pip
 # include python::pip::pyes
-# Package <| alias == 'python-pyes' |>
+# realize Package['python-pyes']
 #
 class python::pip::pyes {
 
@@ -16,9 +16,9 @@ class python::pip::pyes {
     "Unsupported os family ${::osfamily}"
   )
 
-  @package {'pyes':
+  @package {'python-pyes':
     provider => 'pip',
-    alias    => 'python-pyes',
+    name     => 'python-pyes',
   }
 
 }

--- a/manifests/pip/simplejson.pp
+++ b/manifests/pip/simplejson.pp
@@ -6,7 +6,7 @@
 #
 # include python::pip
 # include python::pip::simplejson
-# Package <| alias == 'python-simplejson' |>
+# realize Package['python-simplejson']
 #
 class python::pip::simplejson {
 
@@ -16,9 +16,9 @@ class python::pip::simplejson {
     "Unsupported os family ${::osfamily}"
   )
 
-  @package {'simplejson':
+  @package {'python-simplejson':
     provider => 'pip',
-    alias    => 'python-simplejson',
+    name     => 'simplejson',
   }
 
 }


### PR DESCRIPTION
In Puppet 4, it is not possible to refer to resources by their alias anymore.

This PR changes the way this module works (I'm convinced virtual resources are not a good approach anyway, and classes should suffice).

In a way, this PR makes everything simpler, since you can just use `realize` instead of the ambiguous spaceship operator.