### PR TITLE
Readd space workaround in pip::couchdb

### DIFF
--- a/manifests/pip/couchdb.pp
+++ b/manifests/pip/couchdb.pp
@@ -21,7 +21,7 @@ class python::pip::couchdb {
   # this problem using e.g. composite name identifier
   @package {'python-couchdb':
     provider => 'pip',
-    name     => 'couchdb',
+    name     => ' couchdb',
   }
 
 }


### PR DESCRIPTION
It was really necessary, we weren't kidding.